### PR TITLE
adding contributors.csv and script to generate it

### DIFF
--- a/contributors.csv
+++ b/contributors.csv
@@ -1,0 +1,80 @@
+username,first_name,last_name
+joamatab,Joaquin,Matres
+simbilod,Simon,Bilodeau
+tvt173,Troy,Tamas
+SkandanC,Skandan,Chandrasekar
+MatthewMckee4,Matthew,Mckee
+thomasdorch,Thomas,Dorch
+pre-commit-ci[bot],,
+nikosavola,Niko,Savola
+dependabot[bot],,
+sebastian-goeldi,Sebastian,Goeldi
+flaport,Floris,Laporte
+HelgeGehring,Helge,Gehring
+daquintero,Dario,Antonio Quintero Dominguez
+yaugenst,Yannick,Augenstein
+lucasgrjn,Lucas,Grosjean
+FaragElsayed2,Farag,Elsayed
+Edward-Deacon,Edward,Deacon
+Jelly298,JellyLab,
+jan-david-fischbach,Jan,David Fischbach
+friederike-joehlinger-wavephotonics,,
+fp-matt,Matthew,Larkins
+server5056,,
+atorkmabrains,Amro,Tork
+alexsludds,Alex,Sludds
+lawrence-r,,
+Vivswan,Vivswan,Shah
+thomaslima,Thomas,Ferreira de Lima
+lucas-flexcompute,Lucas,
+QuentinWach,Quentin,Wach
+basnijholt,Bas,Nijholt
+threaddy,fgarbu,
+simenmm,,
+zobristnicholas,Nicholas,Zobrist
+jonbenfri,Jonathan,Friedman
+manoranjanminz,Manoranjan,Minz
+alibillalhammoud,Ali,Hammoud
+95-martin-orion,Orion,Martin
+AntoineGervais,,
+joelslaby,Joel,Slaby
+wuzhonghan,wuzhonghan,
+leochand101,Cramamur,
+kch3782,Changhyun,Kim
+peteshadbolt,Pete,Shadbolt
+jramirez857,Jose,Ramirez
+Daasein,WEI,XIANGYU
+sequoiap,Sequoia,
+gitter-badger,The,Gitter Badger
+mithro,Tim,'mithro' Ansell
+st4eve,Tristan,Austin
+LIU-Yinyi,Yinyi,(Shannon) LIU
+bhnzhang,Bohan,Zhang
+donato-ax,Donato,
+edelmanjm,,
+jaimergp,,
+momchil-flex,,
+peterFecko,,
+pyjavo,Javier,Daza
+rmcamacho,Ryan,Camacho
+sunilkpai,Sunil,Pai
+thanojo,,
+wwwwwwzx,,
+yoshi74ls181,,
+aaronmondal,Aaron,Siddhartha Mondal
+smartalecH,Alec,Hammond
+oskooi,Ardavan,Oskooi
+cloudcalvin,Calvin,M
+dominauta,David,Domenech
+elamdf,Elam,Day-Friedland
+feifanphys,ffaity,
+gronniger,,
+hakancelikdev,Hakan,Çelik
+gJDelavega,John,Delavega
+Python-simulation,Jonathan,Peltier
+lukasc-ubc,Lukas,Chrostowski
+mdecea,Marc,de Cea
+delanema,Matthew,A Delaney
+minrk,Min,RK
+pelmers,Peter,Elmers
+rgiroud,Robin,

--- a/contributors_with_affiliation.csv
+++ b/contributors_with_affiliation.csv
@@ -1,0 +1,77 @@
+username,first_name,last_name,affiliation
+joamatab,Joaquin,Matres,GDSFactory+
+simbilod,Simon,Bilodeau,Google
+tvt173,Troy,Tamas,GDSFactory+
+SkandanC,Skandan,Chandrasekar,University of Waterloo
+MatthewMckee4,Matthew,Mckee,Glasgow University
+thomasdorch,Thomas,Dorch,Hyperlight
+nikosavola,Niko,Savola,Google, Aalto University
+sebastian-goeldi,Sebastian,Goeldi,PsiQuantum
+flaport,Floris,Laporte,GDSFactory+
+HelgeGehring,Helge,Gehring,Google
+daquintero,Dario,Antonio Quintero Dominguez,Flexcompute, University of Bristol
+yaugenst,Yannick,Augenstein,Flexcompute
+lucasgrjn,Lucas,Grosjean,Google
+FaragElsayed2,Farag,Elsayed,Mabrains
+Edward-Deacon,Edward,Deacon,University of Bristol
+Jelly298,JellyLab,,?
+jan-david-fischbach,Jan,David Fischbach,Karlsruhe Institute for Technology
+friederike-joehlinger-wavephotonics,Friederike,Joehlinger,Wavephotonics
+fp-matt,Matthew,Larkins,Freedom Photonics
+server5056,,,?
+atorkmabrains,Amro,Tork,Mabrains
+alexsludds,Alex,Sludds,Lightmatter
+lawrence-r,Lawrence,Rosenfeld,University of Bristol
+Vivswan,Vivswan,Shah,University of Pittsburgh, Carnegie Mellon University
+thomaslima,Thomas,Ferreira de Lima,Quantum Transistors
+lucas-flexcompute,Lucas,Heitzmann,Flexcompute
+QuentinWach,Quentin,Wach,Technical University of Berlin
+basnijholt,Bas,Nijholt,IonQ
+threaddy,fgarbu,,Ugent, imec
+simenmm,Simen,Martinussen,University of Twente
+zobristnicholas,Nicholas,Zobrist,Google
+jonbenfri,Jonathan,Friedman,CUNY
+manoranjanminz,Manoranjan,Minz,IIT Guwahati
+alibillalhammoud,Ali,Hammoud,University of Michigan
+95-martin-orion,Orion,Martin,Google
+AntoineGervais,Antoine,Gervais,EXFO
+joelslaby,Joel,Slaby,Georgia Institute of Technology
+wuzhonghan,Zhonghan,Wu,QoreTek
+leochand101,Cramamur,,Alphacore
+kch3782,Changhyun,Kim,Seoul National University
+peteshadbolt,Pete,Shadbolt,PsiQuantum
+jramirez857,Jose,Ramirez,Cloudzero
+Daasein,Wei,Xiangyu,Tongji University
+sequoiap,Sequoia,Ploeg,Nokia
+mithro,Tim,Ansell,wafer-space
+st4eve,Tristan,Austin,Queen's University
+LIU-Yinyi,Yinyi,Liu,Hong Kong University of Science and Technology
+bhnzhang,Bohan,Zhang,Flexcompute
+donato-ax,Donato,Jiménez Benetó,Axiomatic AI
+edelmanjm,,,?
+jaimergp,Jaime,Rodríguez-Guerra,Quansight
+momchil-flex,Momchil,Minkov,Flexcompute
+peterFecko,Peter,Fecko,Brno University of Technology
+pyjavo,Javier,Daza,WeKnow
+rmcamacho,Ryan,Camacho,Brigham Young University
+sunilkpai,Sunil,Pai,PsiQuantum
+thanojo,,,?
+wwwwwwzx,,,?
+yoshi74ls181,,,?
+aaronmondal,Aaron,Siddhartha Mondal,Trace Machina
+smartalecH,Alec,Hammond,Meta
+oskooi,Ardavan,Oskooi,Meta
+cloudcalvin,Calvin,M,?
+dominauta,David,Domenech,VLC Photonics
+elamdf,Elam,Day-Friedland,UC Berkeley
+feifanphys,ffaity,,?
+gronniger,Gregor,Ronniger,Institut für Mikroelektronik Stuttgart
+hakancelikdev,Hakan,Çelik,Trendyol
+gJDelavega,John,Delavega,Google ?
+Python-simulation,Jonathan,Peltier,NcodiN
+lukasc-ubc,Lukas,Chrostowski,University of British Columbia
+mdecea,Marc,de Cea,Google
+delanema,Matthew,Delaney,University of Southampton
+minrk,Benjamin,Ragan-Kelley,Simula Research Laboratory
+pelmers,Peter,Elmers,Databricks
+rgiroud,Robin,Giroud,?

--- a/get_gdsfactory_contributors.py
+++ b/get_gdsfactory_contributors.py
@@ -1,0 +1,54 @@
+import requests
+import csv
+import os
+
+# Replace these with your values
+GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN")
+REPO_OWNER = "gdsfactory"
+REPO_NAME = "gdsfactory"
+
+HEADERS = {"Authorization": f"token {GITHUB_TOKEN}"}
+
+def get_contributors():
+    contributors = []
+    page = 1
+    while True:
+        url = f"https://api.github.com/repos/{REPO_OWNER}/{REPO_NAME}/contributors"
+        response = requests.get(url, headers=HEADERS, params={"per_page": 100, "page": page})
+        data = response.json()
+        if not data or response.status_code != 200:
+            break
+        contributors.extend(data)
+        page += 1
+    return contributors
+
+def get_user_name(login):
+    url = f"https://api.github.com/users/{login}"
+    response = requests.get(url, headers=HEADERS)
+    if response.status_code != 200:
+        return login, "", ""
+    profile = response.json()
+    full_name = profile.get("name") or ""
+    first, last = "", ""
+    if full_name:
+        parts = full_name.strip().split()
+        if len(parts) == 1:
+            first = parts[0]
+        elif len(parts) > 1:
+            first = parts[0]
+            last = " ".join(parts[1:])
+    return login, first, last
+
+def main():
+    contributors = get_contributors()
+    with open("contributors.csv", mode="w", newline="", encoding="utf-8") as file:
+        writer = csv.writer(file)
+        writer.writerow(["username", "first_name", "last_name"])
+        for contributor in contributors:
+            login = contributor["login"]
+            username, first_name, last_name = get_user_name(login)
+            writer.writerow([username, first_name, last_name])
+    print("✅ contributors.csv has been created.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #1 (once we add the contents to the Acknowledgements section of the paper)

@lucasgrjn

## Summary by Sourcery

Add a script to generate a CSV file of GitHub contributors for the project

New Features:
- Create a Python script that retrieves contributors from the GitHub repository and generates a contributors.csv file with usernames and names

Chores:
- Prepare infrastructure for tracking project contributors